### PR TITLE
Bump Dependency Versions

### DIFF
--- a/RNBraintreeDropIn.podspec
+++ b/RNBraintreeDropIn.podspec
@@ -14,9 +14,9 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
   s.dependency    'React'
-  s.dependency    'Braintree', '5.20.1'
-  s.dependency    'BraintreeDropIn', '9.8.1'
-  s.dependency    'Braintree/DataCollector', '5.20.1'
-  s.dependency    'Braintree/ApplePay', '5.20.1'
-  s.dependency    'Braintree/Venmo', '5.20.1'
+  s.dependency    'Braintree', '5.26.0'
+  s.dependency    'BraintreeDropIn', '9.13.0'
+  s.dependency    'Braintree/DataCollector', '5.26.0'
+  s.dependency    'Braintree/ApplePay', '5.26.0'
+  s.dependency    'Braintree/Venmo', '5.26.0'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.braintreepayments.api:drop-in:6.11.0'
+    implementation 'com.braintreepayments.api:drop-in:6.16.0'
     implementation 'com.facebook.react:react-native:+'
 }
 


### PR DESCRIPTION
Bumps brain tree numbers to remove iOS build errors

Brain Tree made a fix around Sept 2023 for iOS
https://github.com/braintree/braintree-ios-drop-in/pull/426

Brain tree Version updates and dependencies are listed on BrainTree's repo as well
https://github.com/braintree/braintree-ios-drop-in/releases/tag/9.13.0

Screenshots:
Android
![Screenshot_1733254186](https://github.com/user-attachments/assets/85616ccc-ef8a-4179-ba50-befcdd2075ff)
