### PR TITLE
feat(MMM-14922): bump android dropin version to 6.17.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.braintreepayments.api:drop-in:6.16.0'
+    implementation 'com.braintreepayments.api:drop-in:6.17.0'
     implementation 'com.facebook.react:react-native:+'
 }
 


### PR DESCRIPTION
https://github.com/braintree/braintree-android-drop-in/releases/tag/6.17.0